### PR TITLE
Add prepend argument to runtests.py verifier

### DIFF
--- a/lib/kitchen/verifier/runtests.rb
+++ b/lib/kitchen/verifier/runtests.rb
@@ -22,6 +22,7 @@ module Kitchen
       default_config :windows, false
       default_config :enable_filenames, false
       default_config :from_filenames, []
+      default_config :prepend, ''
 
       def call(state)
         info("[#{name}] Verify on instance #{instance.name} with state=#{state}")
@@ -35,6 +36,7 @@ module Kitchen
 	  config[:from_filenames] = repo.diff("origin/#{ENV['CHANGE_TARGET']}", "origin/#{ENV['BRANCH_NAME']}").name_status.keys.select{|file| file.end_with?('.py')}
         end
         command = [
+          (config[:prepend]),
           (config[:windows] ? 'python.exe' : config[:python_bin]),
           File.join(root_path, config[:testingdir], '/tests/runtests.py'),
           '--sysinfo',

--- a/lib/kitchen/verifier/runtests.rb
+++ b/lib/kitchen/verifier/runtests.rb
@@ -22,7 +22,7 @@ module Kitchen
       default_config :windows, false
       default_config :enable_filenames, false
       default_config :from_filenames, []
-      default_config :prepend, ''
+      default_config :prepend, false
 
       def call(state)
         info("[#{name}] Verify on instance #{instance.name} with state=#{state}")
@@ -36,7 +36,7 @@ module Kitchen
 	  config[:from_filenames] = repo.diff("origin/#{ENV['CHANGE_TARGET']}", "origin/#{ENV['BRANCH_NAME']}").name_status.keys.select{|file| file.end_with?('.py')}
         end
         command = [
-          (config[:prepend]),
+          (config[:prepend] ? "#{config[:prepend]}" : ''),
           (config[:windows] ? 'python.exe' : config[:python_bin]),
           File.join(root_path, config[:testingdir], '/tests/runtests.py'),
           '--sysinfo',


### PR DESCRIPTION
For MacOSX tests we need to set the LANG before running the command. This allows us to ensure this command is run on macosx:

`LANG='en_US.UTF-8' python3 /tmp/kitchen/testing/tests/runtests.py....`

with the configuration:

```
            verifier:
              prepend: LANG='en_US.UTF-8'
```